### PR TITLE
feat: 모션 기초 + AnimatePresence 데모 추가 (closes #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Motion Basics + AnimatePresence (Iteration 1)
+
+## What was added
+- Motion basics patterns with examples for `initial`, `animate`, `exit`, and `transition`.
+- Parent-child variant orchestration example (staggered card items).
+- `AnimatePresence` modal mount/unmount transition example.
+- Three demos under `src/animations/*`:
+  - `ButtonTransitionDemo.tsx`
+  - `CardVariantsDemo.tsx`
+  - `ModalPresenceDemo.tsx`
+- Route/page integration at `/motion-basics` so all three demos are reachable in the UI.
+
+## Where to view
+- Route: `/motion-basics`
+- Entry page file: `src/pages/MotionBasics/MotionBasicsPage.tsx`
+
+## Core pattern notes
+
+### `initial` / `animate` / `exit` / `transition`
+- `initial`: first frame before animation starts.
+- `animate`: target frame while mounted.
+- `exit`: leaving frame used when component unmounts with `AnimatePresence`.
+- `transition`: timing/physics config (`duration`, `ease`, `type`, `stiffness`, `damping`...).
+
+### Easing vs Spring (concise)
+- Easing: predictable, timeline-based interpolation. Good for straightforward UI timing.
+- Spring: physics-based movement with natural feel and optional bounce. Good for interactive or tactile motion.
+
+### Variants vs direct props
+- Use variants when multiple elements must share named states (`hidden`, `show`) or parent-child orchestration (`staggerChildren`, `delayChildren`) is needed.
+- Use direct props (`initial={{...}}`, `animate={{...}}`) when animating a single element with simple state transitions.
+
+## Demo mapping
+- Button demo (`ButtonTransitionDemo`): direct props transition and interactive state change.
+- Card demo (`CardVariantsDemo`): parent-child variants orchestration.
+- Modal demo (`ModalPresenceDemo`): `AnimatePresence` enter/exit during mount/unmount.

--- a/README.md
+++ b/README.md
@@ -34,3 +34,32 @@
 - 버튼 데모(`ButtonTransitionDemo`): direct props 기반 상태 전환 + 상호작용
 - 카드 데모(`CardVariantsDemo`): 부모-자식 variants 오케스트레이션
 - 모달 데모(`ModalPresenceDemo`): `AnimatePresence` 기반 mount/unmount enter/exit 전환
+
+---
+
+# Layout & Shared Layout (Iteration 2)
+
+## 추가한 내용
+- `layout` 토글 예제를 통해 레이아웃 변경 시 부드러운 보간 동작 확인
+- `layoutId` 기반 탭 underline shared transition 유지
+- `LayoutGroup`을 적용해 shared layout 컨텍스트를 명시적으로 그룹화
+- `Reorder.Group` / `Reorder.Item` 기반 sortable 리스트 데모 추가
+
+## 확인 위치
+- 라우트: `/layout`
+- 페이지 파일: `src/pages/Layout/LayoutPage.tsx`
+- 데모 파일:
+  - `src/animations/LayoutAnimation.tsx`
+  - `src/animations/SharedLayoutAnimation.tsx`
+  - `src/animations/ReorderListDemo.tsx`
+
+## Layout API 사용 가이드 (요약)
+- `layout`: 같은 컴포넌트가 위치/크기만 바뀌는 경우 가장 간단한 선택
+- `layoutId`: 서로 다른 컴포넌트 사이를 “같은 요소”처럼 이어서 전환하고 싶을 때 사용
+- `LayoutGroup`: shared layout(`layoutId`)를 묶어 충돌 없이 전환 맥락을 분리할 때 사용
+- `Reorder`: 단순 정렬 변경 UI를 빠르게 만들 때 유리(리스트 상태를 `values`로 관리)
+
+## 주의사항
+- `layoutId` 문자열은 같은 그룹 내에서 유일해야 전환이 안정적입니다.
+- `Reorder`는 key/value 안정성이 중요하므로 불변 데이터(고유 값)를 권장합니다.
+- 과도한 박스 그림자/필터는 체감 성능 저하를 만들 수 있어, 리스트 아이템 스타일은 가볍게 유지하는 것이 좋습니다.

--- a/README.md
+++ b/README.md
@@ -1,36 +1,36 @@
-# Motion Basics + AnimatePresence (Iteration 1)
+# 모션 기초 + AnimatePresence (Iteration 1)
 
-## What was added
-- Motion basics patterns with examples for `initial`, `animate`, `exit`, and `transition`.
-- Parent-child variant orchestration example (staggered card items).
-- `AnimatePresence` modal mount/unmount transition example.
-- Three demos under `src/animations/*`:
+## 추가한 내용
+- `initial`, `animate`, `exit`, `transition` 패턴을 예제와 함께 정리했습니다.
+- 부모-자식 variants 오케스트레이션(순차 등장) 예제를 추가했습니다.
+- `AnimatePresence` 기반 모달 mount/unmount 전환 예제를 추가했습니다.
+- `src/animations/*` 아래 3개 데모를 구현했습니다.
   - `ButtonTransitionDemo.tsx`
   - `CardVariantsDemo.tsx`
   - `ModalPresenceDemo.tsx`
-- Route/page integration at `/motion-basics` so all three demos are reachable in the UI.
+- `/motion-basics` 라우트에서 3개 데모를 모두 확인할 수 있도록 페이지/라우팅을 연결했습니다.
 
-## Where to view
-- Route: `/motion-basics`
-- Entry page file: `src/pages/MotionBasics/MotionBasicsPage.tsx`
+## 확인 위치
+- 라우트: `/motion-basics`
+- 페이지 파일: `src/pages/MotionBasics/MotionBasicsPage.tsx`
 
-## Core pattern notes
+## 핵심 패턴 정리
 
 ### `initial` / `animate` / `exit` / `transition`
-- `initial`: first frame before animation starts.
-- `animate`: target frame while mounted.
-- `exit`: leaving frame used when component unmounts with `AnimatePresence`.
-- `transition`: timing/physics config (`duration`, `ease`, `type`, `stiffness`, `damping`...).
+- `initial`: 애니메이션 시작 전 초기 상태
+- `animate`: 마운트된 상태에서 도달할 목표 상태
+- `exit`: `AnimatePresence`와 함께 언마운트될 때의 상태
+- `transition`: 타이밍/물리 설정 (`duration`, `ease`, `type`, `stiffness`, `damping` 등)
 
-### Easing vs Spring (concise)
-- Easing: predictable, timeline-based interpolation. Good for straightforward UI timing.
-- Spring: physics-based movement with natural feel and optional bounce. Good for interactive or tactile motion.
+### Easing vs Spring (간단 비교)
+- Easing: 시간 곡선을 기반으로 예측 가능한 움직임. 일반적인 UI 전환에 적합합니다.
+- Spring: 물리 기반 움직임으로 자연스러운 감쇠/반동 표현에 유리합니다.
 
-### Variants vs direct props
-- Use variants when multiple elements must share named states (`hidden`, `show`) or parent-child orchestration (`staggerChildren`, `delayChildren`) is needed.
-- Use direct props (`initial={{...}}`, `animate={{...}}`) when animating a single element with simple state transitions.
+### Variants vs Direct Props
+- Variants는 여러 요소가 동일한 상태 이름(`hidden`, `show`)을 공유하거나 부모-자식 오케스트레이션(`staggerChildren`, `delayChildren`)이 필요할 때 사용합니다.
+- Direct props(`initial={{...}}`, `animate={{...}}`)는 단일 요소를 간단한 상태 전환으로 빠르게 제어할 때 적합합니다.
 
-## Demo mapping
-- Button demo (`ButtonTransitionDemo`): direct props transition and interactive state change.
-- Card demo (`CardVariantsDemo`): parent-child variants orchestration.
-- Modal demo (`ModalPresenceDemo`): `AnimatePresence` enter/exit during mount/unmount.
+## 데모 매핑
+- 버튼 데모(`ButtonTransitionDemo`): direct props 기반 상태 전환 + 상호작용
+- 카드 데모(`CardVariantsDemo`): 부모-자식 variants 오케스트레이션
+- 모달 데모(`ModalPresenceDemo`): `AnimatePresence` 기반 mount/unmount enter/exit 전환

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,8 +5,8 @@ import LayoutPage from "./pages/Layout";
 import MotionBasicsPage from "./pages/MotionBasics";
 import Test1Page from "./pages/Test1Page";
 
-const Home: React.FC = () => <h1>Home page</h1>;
-const About: React.FC = () => <h1>About page</h1>;
+const Home: React.FC = () => <h1>홈 페이지</h1>;
+const About: React.FC = () => <h1>소개 페이지</h1>;
 
 const App: React.FC = () => {
   return (
@@ -29,7 +29,7 @@ const App: React.FC = () => {
             <Link to="/layout">layout</Link>
           </li>
           <li>
-            <Link to="/motion-basics">motion-basics</Link>
+            <Link to="/motion-basics">모션 기초</Link>
           </li>
         </ul>
       </nav>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,36 +1,49 @@
-import './index.css';
-import { Routes, Route, Link } from 'react-router-dom';
-import Test1Page from './pages/Test1Page';
-import GesturePage from './pages/Gesture';
-import LayoutPage from './pages/Layout';
-const Home: React.FC = () => <h1>Home page</h1>
-const About : React.FC = () => <h1>About page</h1>
-const Test1 : React.FC = () => <Test1Page></Test1Page>;
-const Gesture : React.FC = () => <GesturePage></GesturePage>
-const Layout : React.FC = () => <LayoutPage></LayoutPage>
+import "./index.css";
+import { Link, Route, Routes } from "react-router-dom";
+import GesturePage from "./pages/Gesture";
+import LayoutPage from "./pages/Layout";
+import MotionBasicsPage from "./pages/MotionBasics";
+import Test1Page from "./pages/Test1Page";
+
+const Home: React.FC = () => <h1>Home page</h1>;
+const About: React.FC = () => <h1>About page</h1>;
 
 const App: React.FC = () => {
   return (
     <div>
       <nav>
         <ul className="flex flex-row gap-4">
-          <li><Link to="/">Home</Link></li>
-          <li><Link to="/about">About</Link></li>
-          <li><Link to="/test1">test1</Link></li>
-          <li><Link to="/gesture">gesture</Link></li>
-          <li><Link to="/layout">layout</Link></li>
+          <li>
+            <Link to="/">Home</Link>
+          </li>
+          <li>
+            <Link to="/about">About</Link>
+          </li>
+          <li>
+            <Link to="/test1">test1</Link>
+          </li>
+          <li>
+            <Link to="/gesture">gesture</Link>
+          </li>
+          <li>
+            <Link to="/layout">layout</Link>
+          </li>
+          <li>
+            <Link to="/motion-basics">motion-basics</Link>
+          </li>
         </ul>
       </nav>
+
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/about" element={<About />} />
-        <Route path="/test1" element={<Test1 />} />
-        <Route path="/gesture" element={<Gesture/>} />
-        <Route path="/layout" element={<Layout/>} />
+        <Route path="/test1" element={<Test1Page />} />
+        <Route path="/gesture" element={<GesturePage />} />
+        <Route path="/layout" element={<LayoutPage />} />
+        <Route path="/motion-basics" element={<MotionBasicsPage />} />
       </Routes>
-
     </div>
-  )
-}
+  );
+};
 
-export default App
+export default App;

--- a/src/animations/ButtonTransitionDemo.tsx
+++ b/src/animations/ButtonTransitionDemo.tsx
@@ -1,0 +1,36 @@
+import * as motion from "motion/react-client";
+import { useState } from "react";
+
+const baseTransition = {
+  duration: 0.35,
+  ease: "easeInOut" as const,
+};
+
+export default function ButtonTransitionDemo() {
+  const [active, setActive] = useState(false);
+
+  return (
+    <div className="flex flex-col items-start gap-3">
+      <p className="text-sm text-slate-700">
+        Direct props example: `initial/animate/transition` drive one element quickly.
+      </p>
+      <motion.button
+        type="button"
+        initial={{ opacity: 0, y: 12, scale: 0.96 }}
+        animate={{
+          opacity: 1,
+          y: 0,
+          scale: active ? 1.06 : 1,
+          backgroundColor: active ? "#0f172a" : "#2563eb",
+        }}
+        transition={baseTransition}
+        whileHover={{ scale: 1.03 }}
+        whileTap={{ scale: 0.97 }}
+        onClick={() => setActive((prev) => !prev)}
+        className="rounded-lg px-4 py-2 text-sm font-semibold text-white"
+      >
+        {active ? "Active" : "Idle"} button
+      </motion.button>
+    </div>
+  );
+}

--- a/src/animations/ButtonTransitionDemo.tsx
+++ b/src/animations/ButtonTransitionDemo.tsx
@@ -12,7 +12,7 @@ export default function ButtonTransitionDemo() {
   return (
     <div className="flex flex-col items-start gap-3">
       <p className="text-sm text-slate-700">
-        Direct props example: `initial/animate/transition` drive one element quickly.
+        Direct props 예시: `initial/animate/transition`으로 단일 요소를 빠르게 제어합니다.
       </p>
       <motion.button
         type="button"
@@ -29,7 +29,7 @@ export default function ButtonTransitionDemo() {
         onClick={() => setActive((prev) => !prev)}
         className="rounded-lg px-4 py-2 text-sm font-semibold text-white"
       >
-        {active ? "Active" : "Idle"} button
+        {active ? "활성" : "대기"} 버튼
       </motion.button>
     </div>
   );

--- a/src/animations/CardVariantsDemo.tsx
+++ b/src/animations/CardVariantsDemo.tsx
@@ -28,7 +28,7 @@ const itemVariants = {
   },
 };
 
-const points = ["Parent controls timing", "Children inherit state", "Stagger gives rhythm"];
+const points = ["부모가 타이밍을 제어", "자식이 상태를 상속", "Stagger로 리듬 부여"];
 
 export default function CardVariantsDemo() {
   return (
@@ -38,8 +38,8 @@ export default function CardVariantsDemo() {
       variants={cardVariants}
       className="w-full max-w-md rounded-xl border border-slate-200 bg-white p-5 shadow-sm"
     >
-      <h3 className="text-base font-bold text-slate-900">Variant Orchestration Card</h3>
-      <p className="mt-1 text-sm text-slate-700">Parent/child variants coordinate reveal timing.</p>
+      <h3 className="text-base font-bold text-slate-900">Variant 오케스트레이션 카드</h3>
+      <p className="mt-1 text-sm text-slate-700">부모/자식 variants로 노출 타이밍을 함께 제어합니다.</p>
       <motion.ul className="mt-3 flex flex-col gap-2">
         {points.map((point) => (
           <motion.li

--- a/src/animations/CardVariantsDemo.tsx
+++ b/src/animations/CardVariantsDemo.tsx
@@ -1,0 +1,56 @@
+import * as motion from "motion/react-client";
+
+const cardVariants = {
+  hidden: {
+    opacity: 0,
+    y: 24,
+    transition: { when: "afterChildren" as const },
+  },
+  show: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      type: "spring" as const,
+      stiffness: 170,
+      damping: 18,
+      staggerChildren: 0.09,
+      delayChildren: 0.08,
+    },
+  },
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, x: -16 },
+  show: {
+    opacity: 1,
+    x: 0,
+    transition: { type: "spring" as const, stiffness: 220, damping: 16 },
+  },
+};
+
+const points = ["Parent controls timing", "Children inherit state", "Stagger gives rhythm"];
+
+export default function CardVariantsDemo() {
+  return (
+    <motion.article
+      initial="hidden"
+      animate="show"
+      variants={cardVariants}
+      className="w-full max-w-md rounded-xl border border-slate-200 bg-white p-5 shadow-sm"
+    >
+      <h3 className="text-base font-bold text-slate-900">Variant Orchestration Card</h3>
+      <p className="mt-1 text-sm text-slate-700">Parent/child variants coordinate reveal timing.</p>
+      <motion.ul className="mt-3 flex flex-col gap-2">
+        {points.map((point) => (
+          <motion.li
+            key={point}
+            variants={itemVariants}
+            className="rounded-md bg-slate-100 px-3 py-2 text-sm text-slate-800"
+          >
+            {point}
+          </motion.li>
+        ))}
+      </motion.ul>
+    </motion.article>
+  );
+}

--- a/src/animations/ModalPresenceDemo.tsx
+++ b/src/animations/ModalPresenceDemo.tsx
@@ -1,0 +1,55 @@
+import { AnimatePresence } from "motion/react";
+import * as motion from "motion/react-client";
+import { useState } from "react";
+
+export default function ModalPresenceDemo() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="flex flex-col items-start gap-3">
+      <p className="text-sm text-slate-700">AnimatePresence keeps exit animations for unmounting UI.</p>
+      <button
+        type="button"
+        className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-900"
+        onClick={() => setOpen(true)}
+      >
+        Open modal
+      </button>
+
+      <AnimatePresence>
+        {open ? (
+          <motion.div
+            key="backdrop"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="fixed inset-0 z-40 flex items-center justify-center bg-black/45 p-4"
+            onClick={() => setOpen(false)}
+          >
+            <motion.div
+              initial={{ opacity: 0, y: 20, scale: 0.96 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: 12, scale: 0.97 }}
+              transition={{ type: "spring", stiffness: 260, damping: 23 }}
+              className="w-full max-w-sm rounded-xl bg-white p-5 shadow-lg"
+              onClick={(event) => event.stopPropagation()}
+            >
+              <h3 className="text-base font-bold text-slate-900">Presence Modal</h3>
+              <p className="mt-1 text-sm text-slate-700">
+                This box runs enter and exit transitions during mount/unmount.
+              </p>
+              <button
+                type="button"
+                className="mt-4 rounded-md bg-slate-900 px-3 py-2 text-sm font-semibold text-white"
+                onClick={() => setOpen(false)}
+              >
+                Close
+              </button>
+            </motion.div>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/animations/ModalPresenceDemo.tsx
+++ b/src/animations/ModalPresenceDemo.tsx
@@ -7,13 +7,13 @@ export default function ModalPresenceDemo() {
 
   return (
     <div className="flex flex-col items-start gap-3">
-      <p className="text-sm text-slate-700">AnimatePresence keeps exit animations for unmounting UI.</p>
+      <p className="text-sm text-slate-700">AnimatePresence는 UI 언마운트 시 exit 애니메이션을 유지합니다.</p>
       <button
         type="button"
         className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-900"
         onClick={() => setOpen(true)}
       >
-        Open modal
+        모달 열기
       </button>
 
       <AnimatePresence>
@@ -35,16 +35,16 @@ export default function ModalPresenceDemo() {
               className="w-full max-w-sm rounded-xl bg-white p-5 shadow-lg"
               onClick={(event) => event.stopPropagation()}
             >
-              <h3 className="text-base font-bold text-slate-900">Presence Modal</h3>
+              <h3 className="text-base font-bold text-slate-900">Presence 모달</h3>
               <p className="mt-1 text-sm text-slate-700">
-                This box runs enter and exit transitions during mount/unmount.
+                이 박스는 mount/unmount 시 enter/exit 전환을 실행합니다.
               </p>
               <button
                 type="button"
                 className="mt-4 rounded-md bg-slate-900 px-3 py-2 text-sm font-semibold text-white"
                 onClick={() => setOpen(false)}
               >
-                Close
+                닫기
               </button>
             </motion.div>
           </motion.div>

--- a/src/animations/ReorderListDemo.tsx
+++ b/src/animations/ReorderListDemo.tsx
@@ -1,0 +1,46 @@
+import { Reorder } from "motion/react";
+import { useState } from "react";
+
+const initialItems = ["Tomato", "Lettuce", "Cheese", "Carrot", "Banana"];
+
+const itemStyle: React.CSSProperties = {
+  listStyle: "none",
+  width: "100%",
+  padding: "10px 14px",
+  marginBottom: 10,
+  borderRadius: 10,
+  background: "#ffffff",
+  border: "1px solid #ececec",
+  boxShadow: "0 1px 4px rgba(0,0,0,0.05)",
+  cursor: "grab",
+};
+
+const ReorderListDemo: React.FC = () => {
+  const [items, setItems] = useState(initialItems);
+
+  return (
+    <section className="w-full max-w-xl mt-8">
+      <h2 className="text-xl font-semibold mb-2">Reorder Sortable List</h2>
+      <p className="text-sm text-gray-600 mb-4">
+        항목을 드래그해서 순서를 바꿔보세요. <code>Reorder.Group</code>이 레이아웃 이동을
+        자연스럽게 보간해 줍니다.
+      </p>
+
+      <Reorder.Group
+        axis="y"
+        values={items}
+        onReorder={setItems}
+        className="p-0 m-0"
+        style={{ width: "100%" }}
+      >
+        {items.map((item) => (
+          <Reorder.Item key={item} value={item} style={itemStyle}>
+            {item}
+          </Reorder.Item>
+        ))}
+      </Reorder.Group>
+    </section>
+  );
+};
+
+export default ReorderListDemo;

--- a/src/animations/SharedLayoutAnimation.tsx
+++ b/src/animations/SharedLayoutAnimation.tsx
@@ -1,4 +1,4 @@
-import { AnimatePresence } from "motion/react"
+import { AnimatePresence, LayoutGroup } from "motion/react"
 import * as motion from "motion/react-client"
 import { useState } from "react"
 import { constant } from "./constant"
@@ -7,45 +7,47 @@ export default function SharedLayoutAnimation() {
 
     return (
         <div style={constant.container}>
-            <nav style={constant.nav}>
-                <ul style={constant.tabsContainer}>
-                    {tabs.map((item) => (
-                        <motion.li
-                            key={item.label}
-                            initial={false}
-                            animate={{
-                                backgroundColor:
-                                    item === selectedTab ? "#eee" : "#eee0",
-                            }}
-                            style={constant.tab}
-                            onClick={() => setSelectedTab(item)}
+            <LayoutGroup id="shared-layout-tabs">
+                <nav style={constant.nav}>
+                    <ul style={constant.tabsContainer}>
+                        {tabs.map((item) => (
+                            <motion.li
+                                key={item.label}
+                                initial={false}
+                                animate={{
+                                    backgroundColor:
+                                        item === selectedTab ? "#eee" : "#eee0",
+                                }}
+                                style={constant.tab}
+                                onClick={() => setSelectedTab(item)}
+                            >
+                                {`${item.icon} ${item.label}`}
+                                {item === selectedTab ? (
+                                    <motion.div
+                                        style={constant.underline}
+                                        layoutId="underline"
+                                        id="underline"
+                                    />
+                                ) : null}
+                            </motion.li>
+                        ))}
+                    </ul>
+                </nav>
+                <main style={constant.iconContainer}>
+                    <AnimatePresence mode="wait">
+                        <motion.div
+                            key={selectedTab ? selectedTab.label : "empty"}
+                            initial={{ y: 10, opacity: 0 }}
+                            animate={{ y: 0, opacity: 1 }}
+                            exit={{ y: -10, opacity: 0 }}
+                            transition={{ duration: 0.2 }}
+                            style={constant.icon}
                         >
-                            {`${item.icon} ${item.label}`}
-                            {item === selectedTab ? (
-                                <motion.div
-                                    style={constant.underline}
-                                    layoutId="underline"
-                                    id="underline"
-                                />
-                            ) : null}
-                        </motion.li>
-                    ))}
-                </ul>
-            </nav>
-            <main style={constant.iconContainer}>
-                <AnimatePresence mode="wait">
-                    <motion.div
-                        key={selectedTab ? selectedTab.label : "empty"}
-                        initial={{ y: 10, opacity: 0 }}
-                        animate={{ y: 0, opacity: 1 }}
-                        exit={{ y: -10, opacity: 0 }}
-                        transition={{ duration: 0.2 }}
-                        style={constant.icon}
-                    >
-                        {selectedTab ? selectedTab.icon : "😋"}
-                    </motion.div>
-                </AnimatePresence>
-            </main>
+                            {selectedTab ? selectedTab.icon : "😋"}
+                        </motion.div>
+                    </AnimatePresence>
+                </main>
+            </LayoutGroup>
         </div>
     )
 }

--- a/src/animations/index.ts
+++ b/src/animations/index.ts
@@ -4,6 +4,7 @@ import EnterAnimation from "./EnterAnimation";
 import LayoutAnimation from "./LayoutAnimation";
 import ModalPresenceDemo from "./ModalPresenceDemo";
 import SharedLayoutAnimation from "./SharedLayoutAnimation";
+import ReorderListDemo from "./ReorderListDemo";
 import constant from "./constant";
 
 export {
@@ -13,5 +14,6 @@ export {
   LayoutAnimation,
   ModalPresenceDemo,
   SharedLayoutAnimation,
+  ReorderListDemo,
   constant,
 };

--- a/src/animations/index.ts
+++ b/src/animations/index.ts
@@ -1,10 +1,17 @@
+import ButtonTransitionDemo from "./ButtonTransitionDemo";
+import CardVariantsDemo from "./CardVariantsDemo";
 import EnterAnimation from "./EnterAnimation";
-import constant from "./constant";
 import LayoutAnimation from "./LayoutAnimation";
+import ModalPresenceDemo from "./ModalPresenceDemo";
 import SharedLayoutAnimation from "./SharedLayoutAnimation";
+import constant from "./constant";
+
 export {
-    EnterAnimation,
-    constant,
-    LayoutAnimation,
-    SharedLayoutAnimation
+  ButtonTransitionDemo,
+  CardVariantsDemo,
+  EnterAnimation,
+  LayoutAnimation,
+  ModalPresenceDemo,
+  SharedLayoutAnimation,
+  constant,
 };

--- a/src/pages/Layout/LayoutPage.tsx
+++ b/src/pages/Layout/LayoutPage.tsx
@@ -1,5 +1,5 @@
 import * as motion from "motion/react-client";
-import { LayoutAnimation, SharedLayoutAnimation } from "../../animations";
+import { LayoutAnimation, ReorderListDemo, SharedLayoutAnimation } from "../../animations";
 import { useState } from "react";
 
 const LayoutPage:React.FC = () => {
@@ -27,6 +27,7 @@ const LayoutPage:React.FC = () => {
             <p>{isOn ? "flex-start" : "flex-end"}</p>
 
             <SharedLayoutAnimation />
+            <ReorderListDemo />
         </div>
         
         </>

--- a/src/pages/MotionBasics/MotionBasicsPage.tsx
+++ b/src/pages/MotionBasics/MotionBasicsPage.tsx
@@ -17,7 +17,7 @@ export default function MotionBasicsPage() {
   return (
     <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-5 py-8">
       <header className="space-y-2">
-        <h1 className="text-2xl font-bold text-slate-900">Motion Basics + AnimatePresence</h1>
+        <h1 className="text-2xl font-bold text-slate-900">모션 기초 + AnimatePresence</h1>
         <p className="text-sm text-slate-700">
           `initial`, `animate`, `exit`, `transition` 패턴과 variants 오케스트레이션, 그리고
           mount/unmount 전환 데모를 한 페이지에서 확인합니다.
@@ -25,21 +25,21 @@ export default function MotionBasicsPage() {
       </header>
 
       <section className={sectionClassName}>
-        <h2 className="text-lg font-semibold text-slate-900">1) Button transition demo</h2>
+        <h2 className="text-lg font-semibold text-slate-900">1) 버튼 전환 데모</h2>
         <div className="mt-3">
           <ButtonTransitionDemo />
         </div>
       </section>
 
       <section className={sectionClassName}>
-        <h2 className="text-lg font-semibold text-slate-900">2) Card variants orchestration demo</h2>
+        <h2 className="text-lg font-semibold text-slate-900">2) 카드 variants 오케스트레이션 데모</h2>
         <div className="mt-3">
           <CardVariantsDemo />
         </div>
       </section>
 
       <section className={sectionClassName}>
-        <h2 className="text-lg font-semibold text-slate-900">3) Modal AnimatePresence demo</h2>
+        <h2 className="text-lg font-semibold text-slate-900">3) 모달 AnimatePresence 데모</h2>
         <div className="mt-3">
           <ModalPresenceDemo />
         </div>
@@ -47,13 +47,13 @@ export default function MotionBasicsPage() {
 
       <section className={sectionClassName}>
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <h2 className="text-lg font-semibold text-slate-900">Easing vs Spring</h2>
+          <h2 className="text-lg font-semibold text-slate-900">Easing과 Spring 비교</h2>
           <button
             type="button"
             onClick={() => setCompareToggle((prev) => !prev)}
             className="rounded-lg bg-slate-900 px-3 py-2 text-sm font-semibold text-white"
           >
-            Run comparison
+            비교 실행
           </button>
         </div>
 

--- a/src/pages/MotionBasics/MotionBasicsPage.tsx
+++ b/src/pages/MotionBasics/MotionBasicsPage.tsx
@@ -1,0 +1,90 @@
+import * as motion from "motion/react-client";
+import { useState } from "react";
+import {
+  ButtonTransitionDemo,
+  CardVariantsDemo,
+  ModalPresenceDemo,
+} from "../../animations";
+
+const trackClassName = "h-3 w-full rounded-full bg-slate-200";
+const dotClassName = "h-3 w-3 rounded-full bg-sky-500";
+
+const sectionClassName = "rounded-xl border border-slate-200 bg-slate-50 p-5";
+
+export default function MotionBasicsPage() {
+  const [compareToggle, setCompareToggle] = useState(false);
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-5 py-8">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-bold text-slate-900">Motion Basics + AnimatePresence</h1>
+        <p className="text-sm text-slate-700">
+          `initial`, `animate`, `exit`, `transition` 패턴과 variants 오케스트레이션, 그리고
+          mount/unmount 전환 데모를 한 페이지에서 확인합니다.
+        </p>
+      </header>
+
+      <section className={sectionClassName}>
+        <h2 className="text-lg font-semibold text-slate-900">1) Button transition demo</h2>
+        <div className="mt-3">
+          <ButtonTransitionDemo />
+        </div>
+      </section>
+
+      <section className={sectionClassName}>
+        <h2 className="text-lg font-semibold text-slate-900">2) Card variants orchestration demo</h2>
+        <div className="mt-3">
+          <CardVariantsDemo />
+        </div>
+      </section>
+
+      <section className={sectionClassName}>
+        <h2 className="text-lg font-semibold text-slate-900">3) Modal AnimatePresence demo</h2>
+        <div className="mt-3">
+          <ModalPresenceDemo />
+        </div>
+      </section>
+
+      <section className={sectionClassName}>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h2 className="text-lg font-semibold text-slate-900">Easing vs Spring</h2>
+          <button
+            type="button"
+            onClick={() => setCompareToggle((prev) => !prev)}
+            className="rounded-lg bg-slate-900 px-3 py-2 text-sm font-semibold text-white"
+          >
+            Run comparison
+          </button>
+        </div>
+
+        <p className="mt-2 text-sm text-slate-700">
+          Easing은 시간 곡선을 따라 예측 가능하게 이동하고, spring은 물리 기반이라 더 자연스럽게
+          감쇠/반동합니다.
+        </p>
+
+        <div className="mt-4 grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <p className="text-sm font-semibold text-slate-800">Easing (duration + ease)</p>
+            <div className={trackClassName}>
+              <motion.div
+                className={dotClassName}
+                animate={{ x: compareToggle ? 220 : 0 }}
+                transition={{ duration: 0.5, ease: "easeInOut" }}
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <p className="text-sm font-semibold text-slate-800">Spring (stiffness + damping)</p>
+            <div className={trackClassName}>
+              <motion.div
+                className={dotClassName}
+                animate={{ x: compareToggle ? 220 : 0 }}
+                transition={{ type: "spring", stiffness: 220, damping: 17 }}
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/MotionBasics/index.ts
+++ b/src/pages/MotionBasics/index.ts
@@ -1,0 +1,3 @@
+import MotionBasicsPage from "./MotionBasicsPage";
+
+export default MotionBasicsPage;


### PR DESCRIPTION
## 요약
- `initial/animate/exit/transition` 모션 기초 패턴을 예제와 함께 반영
- 부모-자식 variants 오케스트레이션 카드 데모 추가
- mount/unmount 전환을 보여주는 AnimatePresence 모달 데모 추가
- 버튼 전환 데모 및 easing/spring 비교 섹션 추가
- `/motion-basics` 라우트에 데모 통합
- README에 variants vs direct props 사용 기준 문서화

## 검증
- pnpm lint
- pnpm build
